### PR TITLE
Added german translation

### DIFF
--- a/lang/strings_german.txt
+++ b/lang/strings_german.txt
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Slack Integration
+ * Copyright (C) 2014 Karim Ratib (karim.ratib@gmail.com)
+ *
+ * Slack Integration is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License 2
+ * as published by the Free Software Foundation.
+ *
+ * Slack Integration is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Slack Integration; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ * or see http://www.gnu.org/licenses/.
+ *
+ * @author Roman Allenstein <http://roman-allenstein.de>
+ */
+
+$s_plugin_Slack_ = '';
+$s_plugin_Slack_title = 'Slack Integration';
+$s_plugin_Slack_description = 'Fügt die Integration von Slack (https://slack.com) zu Mantis hinzu.';
+$s_plugin_Slack_config = 'Konfiguration';
+$s_plugin_Slack_channel = 'Slack Channel';
+$s_plugin_Slack_token = 'Slack API Token';
+$s_plugin_Slack_instance = 'Slack Instanz';
+$s_plugin_Slack_bot_name = 'Slack Bot Name';
+$s_plugin_Slack_bot_icon = 'Slack Bot Icon';
+$s_plugin_Slack_default_channel = 'Standard Slack Channel';
+$s_plugin_Slack_channels = 'Slack Channels';
+$s_plugin_Slack_columns = 'Slack Spalten';
+$s_plugin_Slack_bug_created = '[%s] %s erstellte <%s|%s>.';
+$s_plugin_Slack_bug_updated = '[%s] %s aktualsierte <%s|%s>.';
+$s_plugin_Slack_bug_deleted = '[%s] %s löschte %s.';
+$s_plugin_Slack_bugnote_created = "[%s] %s kommentierte den Eintrag <%s|%s>:\n%s";
+$s_plugin_Slack_bugnote_updated = "[%s] %s bearbeitete einen Kommentar im Eintrag <%s|%s>:\n%s";
+$s_plugin_Slack_bugnote_deleted = "[%s] %s löschte einen Kommentar im Eintrag <%s|%s>.";
+$s_plugin_Slack_no_user = '(niemand)';
+$s_plugin_Slack_unknown_field = '(Es liegt keine Information vor, wie das Feld "%s" ausgegeben werden kann.)';
+
+$MANTIS_ERROR['plugin_Slack_ERROR_NO_CURL'] = 'Das Slack Plugin benötigt die cURL PHP Erweiterung (http://php.net/curl)';
+$MANTIS_ERROR['plugin_Slack_ERROR_PHP_VERSION'] = 'Das Slack plugin benötigt PHP 5.3.0 oder höher';


### PR DESCRIPTION
Added german translation, but left the slack-typical labels as channel and token in english.
